### PR TITLE
ci: update node version for actions

### DIFF
--- a/.github/actions/binary-compatible-builds/action.yml
+++ b/.github/actions/binary-compatible-builds/action.yml
@@ -2,7 +2,7 @@ name: 'Set up a CentOS 6 container to build releases in'
 description: 'Set up a CentOS 6 container to build releases in'
 
 runs:
-  using: node12
+  using: node16
   main: 'main.js'
 inputs:
   name:

--- a/.github/actions/github-release/action.yml
+++ b/.github/actions/github-release/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: ''
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'main.js'

--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -8,5 +8,5 @@ inputs:
     default: 'stable'
 
 runs:
-  using: node12
+  using: node16
   main: 'main.js'


### PR DESCRIPTION
Actions on node12 are getting deprecated on 2023-06-14 - https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/

This PR updates node version used in actions defined in this repository.

NOTE: I have not tested whether the JS action script works on node 16. 